### PR TITLE
Fixed Sample Compile Error

### DIFF
--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 
 		<PublishReadyToRun>false</PublishReadyToRun>


### PR DESCRIPTION
Changed the sample to use .NET 7.0 instead of .NET 6.0 as the engine is compiled with .NET 7.0.