### PR TITLE
Added ability to allow use of a custom Serilog logger

### DIFF
--- a/Engine/General/BaseGame.cs
+++ b/Engine/General/BaseGame.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Serilog.Core;
 using Veldrid;
 using Veldrid.Sdl2;
 using Veldrid.StartupUtilities;
@@ -67,11 +68,21 @@ namespace ElementEngine
         }
         #endregion
 
-        public BaseGame()
+        public BaseGame() : this(null) { }
+
+        public BaseGame(Logger logger)
         {
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 
-            Logging.Load();
+            if (logger is null)
+            {
+                Logging.Load();
+            }
+            else
+            {
+                Logging.Load(logger);
+            }
+            
             Load();
         }
 

--- a/Engine/General/BaseGameHeadless.cs
+++ b/Engine/General/BaseGameHeadless.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using ElementEngine.Timer;
+using Serilog.Core;
 
 namespace ElementEngine
 {
@@ -45,11 +46,21 @@ namespace ElementEngine
         }
         #endregion
 
-        public BaseGameHeadless()
+        public BaseGameHeadless() : this(null) { }
+
+        public BaseGameHeadless(Logger logger)
         {
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 
-            Logging.Load();
+            if (logger is null)
+            {
+                Logging.Load();
+            }
+            else
+            {
+                Logging.Load(logger);
+            }
+            
             Load();
         }
 

--- a/Engine/General/Logging.cs
+++ b/Engine/General/Logging.cs
@@ -14,13 +14,22 @@ namespace ElementEngine
         {
             File.Delete("log.txt");
 
-            _logger = new LoggerConfiguration()
+            var logger = new LoggerConfiguration()
                 .MinimumLevel.Verbose()
                 .WriteTo.Console()
                 .WriteTo.File("log.txt",
                     LogEventLevel.Verbose,
                     "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
                 .CreateLogger();
+            
+            Load(logger);
+        }
+
+        public static void Load(Logger logger)
+        {
+            Dispose();
+
+            _logger = logger;
         }
 
         public static void Dispose()


### PR DESCRIPTION
Small change to allow the program creating the `BaseGame` or the `BaseGameHeadless` to pass a custom logger instead of the default one provided.

This change is both source and binary compatible and both have been tested.