### PR TITLE
Update sample to use renamed EnableGamepads method

### DIFF
--- a/Samples/Game.cs
+++ b/Samples/Game.cs
@@ -72,7 +72,7 @@ namespace Samples
             Globals.SetLanguage(SettingsManager.GetSetting<string>("UI", "Language"));
             InputManager.LoadGameControls();
 
-            EnableGameControllers();
+            EnableGamepads();
             UpdateAudioVolume();
 
             Window.Resizable = false;

--- a/Samples/Settings.xml
+++ b/Samples/Settings.xml
@@ -22,8 +22,8 @@
 		<Setting Name="MoveLeft" Value="A,Left" Type="Keyboard" />
 		<Setting Name="MoveRight" Value="D,Right" Type="Keyboard" />
 		
-		<Setting Name="ControllerMove" Value="LeftAxis" Type="GameController" />
-		<Setting Name="ControllerInteract" Value="A" Type="GameController" />
+		<Setting Name="ControllerMove" Value="LeftAxis" Type="Gamepad" />
+		<Setting Name="ControllerInteract" Value="A" Type="Gamepad" />
 		
 		<Setting Name="MouseInteract" Value="Right" Type="Mouse" />
 	</Section>


### PR DESCRIPTION
I noticed the sample project was failing to compile due to the recent rename of the EnableGameControllers method to EnableGamepads. 